### PR TITLE
updated target attribute on linkedin footer link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,9 @@
   <footer>
     <span class="footer built-by">built by wesley davis</span>
     <span class="footer social-links">
-      <a href="https://www.linkedin.com/in/wesleyadavis/" class="linkedin">
+      <a href="https://www.linkedin.com/in/wesleyadavis/" target="_blank"
+        class="linkedin"
+      >
         linkedin
       </a>
       <span class="divider">|</span>


### PR DESCRIPTION
- fixed target attribute of linkedin <a> tag in footer to direct clicks to new tab as consistent with other external links on the site